### PR TITLE
feat(cli): allow users to preview full commit messages before choosing

### DIFF
--- a/commitmint/cli.py
+++ b/commitmint/cli.py
@@ -89,17 +89,30 @@ def generate(
         console.print(table)
 
         # User selection
-        choice = Prompt.ask(
-            "\nSelect an option:",
-            choices=[str(i) for i in range(1, len(options.options) + 1)] + ["quit"],
-            default="1"
-        )
+        while True:
+            choice = Prompt.ask(
+                "\nSelect an option:",
+                choices=[str(i) for i in range(1, len(options.options) + 1)] + ["preview", "quit"],
+                default="1"
+            )
 
-        if choice == "quit":
-            console.print("[yellow]Cancelled.[/yellow]")
-            return
+            if choice == "quit":
+                console.print("[yellow]Cancelled.[/yellow]")
+                return
+
+            if choice == "preview":
+                console.print("\n[bold]Full message previews:[/bold]\n")
+                for i, msg in enumerate(options.options, 1):
+                    console.print(f"[bold cyan]Option {i}:[/bold cyan]")
+                    console.print(Panel(msg.format(), border_style="dim"))
+                    console.print()
+                continue  # Go back to selection prompt
+
+            # If we get here, it's a valid number selection
+            break
 
         selected = options.options[int(choice) - 1]
+
 
         # Show full message
         console.print("\n[bold]Selected commit message:[/bold]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commitmint"
-version = "0.5.0"
+version = "0.5.5"
 description = "the freshest AI commit message generator"
 license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.11"


### PR DESCRIPTION
Adds a user-facing 'preview' command in the commit message selection flow so users can view fully formatted messages (rendered in panels) for each option before making a choice. 'quit' still cancels the operation and numeric input selects the final message.